### PR TITLE
Fixed the issue with blog comments not appearing

### DIFF
--- a/lib/rtp-comments.php
+++ b/lib/rtp-comments.php
@@ -86,7 +86,7 @@ function rtp_only_comment_count( $count, $post_id ) {
 	$comments		 = get_approved_comments( $post_id );
 	$comment_count	= 0;
 	foreach ( $comments as $comment ) {
-		if ( $comment->comment_type == '' ) {
+		if ( $comment->comment_type != '' ) {
 			$comment_count++;
 		}
 	}


### PR DESCRIPTION
Updated the `rtp_only_comment_count()` function to check for and count comments with a non-empty `comment_type`.